### PR TITLE
Candidate and partner public IDs and TC partner prefix (schema)

### DIFF
--- a/components/schemas/v1/Candidate.yaml
+++ b/components/schemas/v1/Candidate.yaml
@@ -127,7 +127,7 @@ properties:
     type: string
     description: Notes related to the candidate's conflict participation.
     example: "Conflict participation notes"
-  contactConsentPartners:
+  contactConsentTcPartners:
     type: boolean
     description: Indicates whether the candidate has given consent to be contacted by partners.
     example: true

--- a/components/schemas/v1/Candidate.yaml
+++ b/components/schemas/v1/Candidate.yaml
@@ -129,7 +129,7 @@ properties:
     example: "Conflict participation notes"
   contactConsentTcPartners:
     type: boolean
-    description: Indicates whether the candidate has given consent to be contacted by partners.
+    description: Indicates whether the candidate has given consent to be contacted by TC partners.
     example: true
   contactConsentRegistration:
     type: boolean
@@ -372,10 +372,6 @@ properties:
     description: Education level of the candidate's partner.
     allOf:
       - $ref: ./EducationLevel.yaml
-  partnerEduLevelNotes:
-    type: string
-    description: Notes related to the education level of the candidate's partner.
-    example: "Partner education level notes"
   partnerEnglish:
     description: Indicates whether the candidate's partner speaks English.
     allOf:
@@ -401,10 +397,6 @@ properties:
     description: Occupation of the candidate's partner.
     allOf:
       - $ref: ./Occupation.yaml
-  partnerOccupationNotes:
-    type: string
-    description: Notes related to the occupation of the candidate's partner.
-    example: "Partner occupation notes"
   residenceStatus:
     description: Residence status of the candidate.
     allOf:

--- a/components/schemas/v1/Candidate.yaml
+++ b/components/schemas/v1/Candidate.yaml
@@ -356,10 +356,10 @@ properties:
     description: Indicates whether the candidate's partner is registered.
     allOf:
       - $ref: ../common/enums/yes_no_unsure.yaml
-  partnerCandidatePublicId:
+  partnerPublicId:
     type: string
     format: uuid
-    description: Anonymised ID of the candidate's partner (if also a candidate in the system)
+    description: Anonymised public ID of the candidate's partner (if also a candidate in the system)
     example: 123e4567-e89b-12d3-a456-426614174000
   partnerCitizenship:
     type: array

--- a/components/schemas/v1/Candidate.yaml
+++ b/components/schemas/v1/Candidate.yaml
@@ -1,7 +1,7 @@
 type: object
 description: Represents a Candidate with detailed properties and relationships.
 properties:
-  uuid:
+  publicId:
     type: string
     format: uuid
     description: Universally unique identifier for the candidate
@@ -356,10 +356,10 @@ properties:
     description: Indicates whether the candidate's partner is registered.
     allOf:
       - $ref: ../common/enums/yes_no_unsure.yaml
-  partnerCandidateId:
+  partnerCandidatePublicId:
     type: string
     format: uuid
-    description: ID of the candidate's partner (if also a candidate in the system)
+    description: Anonymised ID of the candidate's partner (if also a candidate in the system)
     example: 123e4567-e89b-12d3-a456-426614174000
   partnerCitizenship:
     type: array

--- a/components/schemas/v1/CandidateVisaCheck.yaml
+++ b/components/schemas/v1/CandidateVisaCheck.yaml
@@ -18,7 +18,8 @@ properties:
     allOf:
       - $ref: ../common/enums/yes_no.yaml
   characterAssessment:
-    description: Meets character assessment for the visa. 
+    description: Meets character assessment for the visa.
+    allOf:
       - $ref: ../common/enums/yes_no.yaml
   securityRisk:
     description: Meets security risk assessment for the visa.

--- a/components/schemas/v1/IdentifiableCandidate.yaml
+++ b/components/schemas/v1/IdentifiableCandidate.yaml
@@ -35,6 +35,10 @@ allOf:
         type: string
         description: Candidate's address line 1.
         example: "123 Main St"
+      partnerCandidate:
+        description: The candidate's partner (if also a candidate in the system)
+        allOf:
+          - $ref: './IdentifiablePartner.yaml'
       regoIp:
         type: string
         description: IP address of the candidate during registration.

--- a/components/schemas/v1/IdentifiableCandidate.yaml
+++ b/components/schemas/v1/IdentifiableCandidate.yaml
@@ -152,5 +152,16 @@ allOf:
         description: Link to the corresponding candidate's video profile.
         example: "https://drive.google.com/video/12345678"
 
+      # The below fields use the TC raw data field names but are mapped to public API field names
+      # For example contactConsentPartners is mapped to contactConsentTcPartners in the public API model
+      # These fields will eventually be renamed in the TC database and service to match the public API model
+      # The below fields are thus temporary and will be removed  once the TC database and service fields are renamed
+      # See: Issue #todo
+      contactConsentPartners:
+        type: boolean
+        description: Indicates whether the candidate has given consent to be contacted by partners.
+        example: true
+
+
     required:
       - candidateNumber

--- a/components/schemas/v1/IdentifiableCandidate.yaml
+++ b/components/schemas/v1/IdentifiableCandidate.yaml
@@ -159,7 +159,7 @@ allOf:
       # See: Issue #todo
       contactConsentPartners:
         type: boolean
-        description: Indicates whether the candidate has given consent to be contacted by partners.
+        description: Indicates whether the candidate has given consent to be contacted by TC partners.
         example: true
 
 

--- a/components/schemas/v1/IdentifiablePartner.yaml
+++ b/components/schemas/v1/IdentifiablePartner.yaml
@@ -1,0 +1,15 @@
+type: object
+properties:
+  id:
+    type: string
+    description: Unique Talent Catalog identifier for the candidate's partner.
+    example: 1234567
+  candidateNumber:
+    type: string
+    description: Unique candidate number for the candidate's partner.
+    example: "12345678"
+  publicId:
+    type: string
+    format: uuid
+    description: Anonymised public ID of the candidate's partner
+    example: 123e4567-e89b-12d3-a456-426614174000

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -28,8 +28,8 @@ servers:
 paths:
   /v1/candidates:
     $ref: paths/v1/candidates.yaml
-  /v1/candidates/{candidateId}:
-    $ref: ./paths/v1/candidates-candidateId.yaml
+  /v1/candidates/{publicId}:
+    $ref: ./paths/v1/candidates-publicId.yaml
   /v1/candidates/byListId/{listId}: # todo - replace with /v1/lists/{listId}/candidates
     $ref: ./paths/v1/candidates-byListId-listId.yaml
   /v1/candidates/bySearchId/{searchId}: # todo - replace with /v1/searches/{searchId}/candidates

--- a/paths/v1/candidates-byListId-listId.yaml
+++ b/paths/v1/candidates-byListId-listId.yaml
@@ -8,7 +8,7 @@ get:
     - name: listId
       in: path
       required: true
-      description: A unique list identifier for retrieving candidates associated with a specific list.
+      description: A unique public identifier for retrieving candidates associated with a specific list.
       schema:
         type: string
         format: uuid

--- a/paths/v1/candidates-bySearchId-searchId.yaml
+++ b/paths/v1/candidates-bySearchId-searchId.yaml
@@ -8,7 +8,7 @@ get:
     - name: searchId
       in: path
       required: true
-      description: A unique search identifier for retrieving candidates associated with a specific search.
+      description: A unique public identifier for retrieving candidates associated with a specific search.
       schema:
         type: string
         format: uuid

--- a/paths/v1/candidates-candidateId.yaml
+++ b/paths/v1/candidates-candidateId.yaml
@@ -8,7 +8,7 @@ get:
     - name: candidateId
       in: path
       required: true
-      description: Unique ID of the candidate to retrieve
+      description: Unique public ID of the candidate to retrieve
       schema:
         type: string
         format: uuid

--- a/paths/v1/candidates-publicId.yaml
+++ b/paths/v1/candidates-publicId.yaml
@@ -1,11 +1,11 @@
 get:
-  summary: Retrieve an anonymised candidate by candidate ID
-  description: Fetches details of an anonymised candidate by their unique candidate ID.
+  summary: Retrieve an anonymised candidate by candidate public ID
+  description: Fetches details of an anonymised candidate by their unique public candidate ID.
   tags:
     - Candidates
-  operationId: getCandidateById
+  operationId: getCandidateByPublicId
   parameters:
-    - name: candidateId
+    - name: publicId
       in: path
       required: true
       description: Unique public ID of the candidate to retrieve


### PR DESCRIPTION
This PR:

- Updates the schema and endpoints to use candidate public IDs
- Adds "tc" prefix to Talent Catalog partner fields to distinguish from a candidate's "life" partner
- Publishes candidate partners' public ids on the api
- Adds unit tests for api mappings
