### PR TITLE
fix-windows-gpg-key-secret-env-limit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -164,7 +164,12 @@ publishing {
 def signingKeyId = System.getenv("GPG_SIGNING_KEY_ID") ?: project.findProperty("signing.keyId")
 def signingKey = System.getenv("GPG_SECRET_KEY") ?: project.findProperty("signing.secretKey")
 def signingPassword = System.getenv("GPG_SIGNING_PASSWORD") ?: project.findProperty("signing.password")
-
+// Check if the GPG_SECRET_KEY environment variable is a file path
+if (signingKey && new File(signingKey).exists()) {
+    // It's a file path, so read the file content into signingKey
+    def file = new File(signingKey)
+    signingKey = file.text  // Read the file content into the signingKey variable
+}
 signing {
     useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
     sign(publishing.publications)


### PR DESCRIPTION
After more investigation and spending a lot of time trying to set the private key in Windows environment variables, I finally found that there is a limitation in the number of characters that can be stored in Windows environment variables. Unfortunately, our private key is larger than that limit (the limit number is 32,767 characters), so I couldn't set it.
On Windows, I found a way to store the key in a separate file and then read it into the **GPG_SECRET_KEY** variable.
So, if I add these two lines in the gradle file, it will sign and fix the issue:

```
def signingKeyId = System.getenv("GPG_SIGNING_KEY_ID") ?: project.findProperty("signing.keyId")
def signingKey = System.getenv("GPG_SECRET_KEY") ?: project.findProperty("signing.secretKey")
def signingPassword = System.getenv("GPG_SIGNING_PASSWORD") ?: project.findProperty("signing.password")
FOR WINDOWS USERS
// Check if the GPG_SECRET_KEY environment variable is a file path
if (signingKey && new File(signingKey).exists()) {
    // It's a file path, so read the file content into signingKey
    def file = new File(signingKey)
    signingKey = file.text  // Read the file content into the signingKey variable
}
```
