### PR TITLE
tc-api-spec v1.0.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
 // todo we will publish to org.tctalent once the namespace has been setup and verified on Maven central
 //group = 'org.tctalent'
 group = 'io.github.sadatmalik'
-version = '1.0.3'
+version = '1.0.5'
 
 // Java toolchain configuration
 java {


### PR DESCRIPTION
Tiny PR that promotes a version 1.0.5 of the tc-api artefact to maven central