### PR TITLE
update production and staging servers

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -44,10 +44,10 @@ tags:
     description: Operations related to anonymised candidates.
 
 servers:
-  - url: https://api.tctalent.org
-    description: Production server
   - url: https://test.api.tctalent.org
     description: Staging server
+  - url: https://api.tctalent.org
+    description: Production server
 
 paths:
   /v1/candidates:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -27,7 +27,7 @@ info:
 
 
   version: 1.0.0
-  termsOfService: https://tctalent.org/terms
+#  termsOfService: https://tctalent.org/terms
   contact:
     name: Talent Catalog API Support
     url: https://github.com/Talent-Catalog/tc-api-spec

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -44,9 +44,9 @@ tags:
     description: Operations related to anonymised candidates.
 
 servers:
-  - url: https://tctalent.org/ads
+  - url: https://api.tctalent.org
     description: Production server
-  - url: https://tctalent-test.org/ads
+  - url: https://test.api.tctalent.org
     description: Staging server
 
 paths:


### PR DESCRIPTION
This PR 

- points the staging and prod API environments to test.api.tctalent.org and api.tctalent.org respectively
- hides the terms of service until ready to link

