### PR TITLE
re-enables openapi linting

### DIFF
--- a/redocly.yaml
+++ b/redocly.yaml
@@ -1,3 +1,6 @@
+extends:
+  - recommended
+
 logo:
   image: ./assets/tc-logo-2.png
   altText: Talent Catalog logo


### PR DESCRIPTION
Tiny PR that adds the "extends" section to redocly.yaml in order to reenable the openapi lint command.