### PR TITLE
fixes minor typo in field name - use camel case not snake

### DIFF
--- a/components/schemas/v1/LanguageLevel.yaml
+++ b/components/schemas/v1/LanguageLevel.yaml
@@ -10,7 +10,7 @@ properties:
     type: string
     description: The name of the language proficiency level.
     example: "Full Professional Proficiency"
-  cefr_level:
+  cefrLevel:
     type: string
     description: The CEFR code for the language proficiency level.
     allOf:


### PR DESCRIPTION
Tiny PR that corrects the CEFR level API field name -- to use camel case, not snake