### PR TITLE
Ehsan/tc-1161-update-github-actions-to-versions-compatible-with-nodejs-24

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Set up Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: '17'


### PR DESCRIPTION
Upgrade GitHub Actions dependencies to Node.js 24-compatible versions across CI/CD workflows.

Includes updates for checkout,  setup-java.

No application code or runtime behavior is changed.