### PR TITLE
Ehsan/tc-1476-fix-tc-api-spec-codeowners-catch-all-rule

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@camerojo @sadatmalik
+* @camerojo @sadatmalik


### PR DESCRIPTION
Update the GitHub CODEOWNERS entry so the listed maintainers are assigned to every repository file by prefixing the rule with `*`.